### PR TITLE
C125-182: Restoring annotation config fragment

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -319,7 +319,14 @@
                 }
               }
             }
-          }, "AutoMapUpdate", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
+          }, "AutoMapUpdate", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", {
+            "name": "Annotations",
+            "cfg": {
+              "lineDashOptions": [{"value": "1 0"}, {"value":"10 50 30"}, {"value":"6 6"}, {"value":"20 20"}, {"value":"30 30"}],
+              "symbolsPath": "assets/symbols/",
+              "defaultShape": "CMP"
+            }
+          },
             {
               "name": "Share",
               "cfg": {


### PR DESCRIPTION
## Description
Restoring the annotation config fragment that was accidentally removed in earlier commits

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix

##Issue

**What is the current behavior?**
#182  

**What is the new behavior?**
https://github.com/geosolutions-it/austrocontrol-C125/blob/master/localConfig.json#L256

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
