### PR TITLE
#157: Length measurement - Enhancement

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -430,8 +430,11 @@
                 "name": "Measure",
                 "cfg": {
                   "defaultOptions": {
+                    "showSegmentLengths": true,
                     "showAddAsAnnotation": true,
-                    "trueBearing":{
+                    "showCoordinateEditor": true,
+                    "showLengthAndBearingLabel": true,
+                    "trueBearing": {
                       "measureTrueBearing": true,
                       "fractionDigits": 0
                     }


### PR DESCRIPTION
## Description
Length measurement enhancement for displaying Length, true bearing in coordinated editor as on the map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

##Issue

**What is the current behavior?**
#157 

**What is the new behavior?**
Length measurement - Enhancement
- Length, true bearing for each line segment will be displayed between the defined coordinates.
- Length, true bearing for each line segment will be displayed in the map following the respective line element.
- Length and bearing for each line segment will be stored when the measurement is stored as annotation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
