### PR TITLE
#170: Support for ENV with locale info

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -25,6 +25,9 @@
           }
       }
     },
+    "localizedLayerStyles": {
+      "name": "mapstore_language"
+    },
     "authenticationRules": [{
         "urlPattern": ".*geostore.*",
         "method": "bearer"


### PR DESCRIPTION
## Description
- Add config to support EVN query parameter  with locale info for GFI requests and GetMap
- Updated Mapstore submodule to latest

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#170 

**What is the new behavior?**
The requests is now fired with locale data to the ENV query parameter

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
