### PR TITLE
#148: Add localized formControl to Bookmark config

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,6 @@
         "@terrestris/base-util": "0.1.4",
         "@terrestris/ol-util": "3.0.0",
         "@turf/area": "4.1.0",
-        "@terrestris/base-util": "0.1.4",
-        "@terrestris/ol-util": "3.0.0",
         "@turf/bbox": "4.1.0",
         "@turf/bbox-polygon": "5.1.5",
         "@turf/boolean-contains": "5.1.5",
@@ -247,7 +245,6 @@
         "w3c-schemas": "1.3.1",
         "webfontloader": "1.6.28",
         "wellknown": "0.5.0",
-        "webfontloader": "1.6.28",
         "xml2js": "0.4.17",
         "xmldom": "0.3.0",
         "xpath": "0.0.27"


### PR DESCRIPTION
## Description
This PR contains the Mapstore submodule updated to latest which contains the localized formControl in Bookmark feature  and library clean up

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
https://github.com/geosolutions-it/austrocontrol-C125/issues/148#issuecomment-701939572 

**What is the new behavior?**
Based on the language selected, the delimiter will be displayed in the number field for Bookmark config

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
