### PR TITLE
Measure panel translation texts for tooltip

### DIFF
--- a/translations/data.de-DE.json
+++ b/translations/data.de-DE.json
@@ -2,7 +2,8 @@
     "locale": "de-DE",
     "messages": {
         "measureComponent": {
-            "addAsAnnotaion": "Als Anmerkung hinzufügen",
+            "addAsAnnotation": "Als Notiz hinzufügen (Kann erneut bearbeitet werden)",
+            "addAsLayer": "Als Layer hinzufügen (Kann nicht mehr bearbeitet werden)",
             "newMeasure": "Neue Anmerkung"
         },
          "dateFilter": {

--- a/translations/data.en-US.json
+++ b/translations/data.en-US.json
@@ -2,7 +2,8 @@
     "locale": "en-US",
     "messages": {
         "measureComponent": {
-            "addAsAnnotaion": "Add as annotation",
+            "addAsAnnotation": "Add as annotation (Can be edited again)",
+            "addAsLayer": "Add as layer (Cannot be edited again)",
             "newMeasure": "New annotation"
         },
         "dateFilter": {


### PR DESCRIPTION
## Description
This PR adds new translation texts for tooltips (Add as layer and Add as annotation buttons in measure panel)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#238 

**What is the new behavior?**
The translation texts for Add as layer and Add as annotation button on measure panel will be as per new suggestions from client
Ref: https://github.com/geosolutions-it/austrocontrol-C125/issues/238#issuecomment-736367281

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
